### PR TITLE
Add help text on no input.

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,8 @@ const app = new App({
 			case 'list':
 				return listStatuses(command, respond);
 			case '':
+			case undefined:
+			case null:
 				return helpText(command,respond);
 			default:
 				return setStatus(command, respond);

--- a/index.js
+++ b/index.js
@@ -25,11 +25,69 @@ const app = new App({
 				return clearStatus(command, respond);
 			case 'list':
 				return listStatuses(command, respond);
+			case '':
+				return helpText(command,respond);
 			default:
 				return setStatus(command, respond);
 		}
 	});	
 })();
+
+async function helpText(command,respond) {
+	let response = {
+		"blocks": [
+			{
+				"type": "header",
+				"text": {
+					"type": "plain_text",
+					"text": "CCI Location Bot"
+				}
+			},
+			{
+				text: "Location Bot will quickly update your status to show which site you are at without having to change it manually in your profile."
+			},
+			{
+				text: "Available commands:"
+			},
+			{
+				type: "section",
+				text: {
+					type: "mrkdwn",
+					text: "- `/location _[building]_` – This sets the building location using a simple code, like `pr` for Peckham Road, or `hh` for High Holborn."
+				}
+			},
+			{
+				type: "section",
+				text: {
+					type: "mrkdwn",
+					text: "- `/location list` – This lists all locations and their codes and aliases."
+				}
+			},
+			{
+				type: "section",
+				text: {
+					type: "mrkdwn",
+					text: "- `/location clear` – This clears your current status."
+				}
+			},
+			{
+				type: "section",
+				text: {
+					type: "mrkdwn",
+					text: "- `/location` - No input will show a short help text."
+				}
+			},
+			{
+				type: "section",
+				text: {
+					type: "mrkdwn",
+					text: "If you want to add a new location, or to file any bugfixes, please submit [a pull request on GitHub](https://github.com/ual-cci/location-bot/pulls)."
+				}
+			},
+		]
+	};
+	await respond(response);
+}
 
 async function clearStatus(command, respond) {
 	try {

--- a/readme.md
+++ b/readme.md
@@ -6,8 +6,9 @@ Location Bot will quickly update your status to show which site you are at witho
 - `/location _[building]_` – This sets the building location using a simple code, like "pr" for Peckham Road, or "hh" for High Holborn.
 - `/location list` – This lists all locations and their codes and aliases.
 - `/location clear` – This clears your current status.
+- `/location` - No input will show a short help text.
 
-If you want to add a new location please submit a pull request on GitHub.
+If you want to add a new location please submit [a pull request on GitHub](https://github.com/ual-cci/location-bot/pulls).
 
 ## Adding a new location
 Simply edit `locations.json` adding a new location with this format:


### PR DESCRIPTION
When a user types `/location`, it'd be good if some default help text was supplied.

Disclaimer: I've not actually tested this against a live API, meaning I cannot confirm that the handling of `command.text` for text being non-existent is right, but I've defensively tested against `null`, `undefined`, and `''`. The text supplied is derived from the README.